### PR TITLE
Suppress output from git clean and configure

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -5,7 +5,7 @@ if [ -z "$CORES" ]; then
 fi
 
 function Q {
-  if ! "$@" > /tmp/ruby_ci_log; then
+  if ! "$@" &> /tmp/ruby_ci_log; then
     cat /tmp/ruby_ci_log
     exit 1
   fi


### PR DESCRIPTION
`git clean` and `configure` are both pretty noisy in output. This pull request silences them unless something went wrong.
