### PR TITLE
Add script/deploy script

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function try {
+  echo "$@"
+  if ! "$@" &> log; then
+    echo "*** '$@' FAILED" 1>&2
+    cat log 1>&2
+    exit 1
+  fi
+}
+
+cd "$(dirname "$0")/.."
+
+try autoconf
+try ./configure --prefix=/data/ruby --disable-install-doc
+try make -j 4
+try make install


### PR DESCRIPTION
This adds a `script/deploy` script that is executed when Ruby is deployed.

cc @github/mri-hackers 
