### PR TITLE
Bigdecimal division fix for bug#9316

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+Tue Jan 14 02:20:00 2014  Kenta Murata  <mrkn@mrkn.jp>
+
+	* ext/bigdecimal/bigdecimal.c (BigDecimal_divide): Add an additional
+	  digit for the quotient to be compatible with bigdecimal 1.2.1 and
+	  the former.  [ruby-core:59365] [#9316] [#9305]
+
+	* test/bigdecimal/test_bigdecimal.rb: tests for the above change.
+
+	* ext/bigdecimal/bigdecimal.gemspec: bigdecimal version 1.2.4.
+
 Thu Dec 26 03:28:11 2013  Koichi Sasada  <ko1@atdot.net>
 
 	* vm_insnhelper.c (argument_error): insert dummy frame to make

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1221,8 +1221,10 @@ BigDecimal_divide(Real **c, Real **res, Real **div, VALUE self, VALUE r)
 
     *div = b;
     mx = a->Prec + vabs(a->exponent);
-    if (mx<b->Prec + vabs(b->exponent)) mx = b->Prec + vabs(b->exponent);
-    mx =(mx + 1) * VpBaseFig();
+    if (mx < b->Prec + vabs(b->exponent)) mx = b->Prec + vabs(b->exponent);
+    mx++; /* NOTE: An additional digit is needed for the compatibility to
+                   the version 1.2.1 and the former.  */
+    mx = (mx + 1) * VpBaseFig();
     GUARD_OBJ((*c), VpCreateRbObject(mx, "#0"));
     GUARD_OBJ((*res), VpCreateRbObject((mx+1) * 2 +(VpBaseFig() + 1), "#0"));
     VpDivd(*c, *res, a, b);

--- a/ext/bigdecimal/bigdecimal.gemspec
+++ b/ext/bigdecimal/bigdecimal.gemspec
@@ -1,5 +1,5 @@
 # -*- ruby -*-
-_VERSION = "1.2.3"
+_VERSION = "1.2.4"
 date = %w$Date::                           $[1]
 
 Gem::Specification.new do |s|

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -701,6 +701,10 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, (BigDecimal.new("-0") / 1).sign)
     assert_equal(2, BigDecimal.new("2") / 1)
     assert_equal(-2, BigDecimal.new("2") / -1)
+
+    assert_equal(BigDecimal('1486.868686869'), BigDecimal('1472.0') / BigDecimal('0.99'), '[ruby-core:59365] [#9316]')
+
+    assert_equal(4.124045235, BigDecimal('0.9932') / (700 * BigDecimal('0.344045') / BigDecimal('1000.0')), '[#9305]')
   end
 
   def test_div_with_float


### PR DESCRIPTION
You can also just add the following to your `Gemfile`:

`gem 'bigdecimal', '1.2.4'`
