### PR TITLE
merge revision(s) 44370: [Backport #9576]

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1167,7 +1167,7 @@ rb_hash_reject(VALUE hash)
 #endif
 	}
     }
-#if HASH_REJECT_COPY_MISC_ATTRIBUTES
+#if HASH_REJECT_COPY_EXTRA_STATES
     result = rb_hash_dup_empty(hash);
 #else
     result = rb_hash_new();


### PR DESCRIPTION
This backport resolves a regression in 2.1.1 with Hash#reject

This patch will fix the behavior and will be released in 2.1.2, however is the expected behavior in 2.2.0

See ruby/www.ruby-lang.org#666 for more information.
