### PR TITLE
fix compilation against readline-6.3

### DIFF
--- a/ext/readline/extconf.rb
+++ b/ext/readline/extconf.rb
@@ -19,6 +19,10 @@ def readline.have_func(func)
   return super(func, headers)
 end
 
+def readline.have_type(type)
+  return super(type, headers)
+end
+
 dir_config('curses')
 dir_config('ncurses')
 dir_config('termcap')
@@ -94,4 +98,11 @@ readline.have_func("clear_history")
 readline.have_func("rl_redisplay")
 readline.have_func("rl_insert_text")
 readline.have_func("rl_delete_text")
+unless readline.have_type("rl_hook_func_t*")
+  # rl_hook_func_t is available since readline-4.2 (2001).
+  # Function is removed at readline-6.3 (2014).
+  # However, editline (NetBSD 6.1.3, 2014) doesn't have rl_hook_func_t.
+  $defs << "-Drl_hook_func_t=Function"
+end
+
 create_makefile("readline")

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -1974,7 +1974,7 @@ Init_readline()
 
     rl_attempted_completion_function = readline_attempted_completion_function;
 #if defined(HAVE_RL_PRE_INPUT_HOOK)
-    rl_pre_input_hook = (Function *)readline_pre_input_hook;
+    rl_pre_input_hook = (rl_hook_func_t *)readline_pre_input_hook;
 #endif
 #ifdef HAVE_RL_CATCH_SIGNALS
     rl_catch_signals = 0;


### PR DESCRIPTION
This is a squashed cherry-pick of the following commits:

```
10f60e4e2e477ae3fd6c26c31d4753cbd412d84b
664813677963792e2ad36ef9370107dc41c7f27b
d2a8e28597df946842f44d6e0d2cbfe98863b877
```

They fix a problem where ruby cannot compile against readline-6.3, because upstream dropped support for "Function" in favor of rl_hook_func_t. This version of readline is present, e.g., on Debian unstable.
