### PR TITLE
gc: Export `ruby_memnotify`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6192,6 +6192,21 @@ objspace_xfree(rb_objspace_t *objspace, void *ptr, size_t old_size)
     objspace_malloc_increase(objspace, ptr, 0, old_size, MEMOP_TYPE_FREE);
 }
 
+void
+ruby_memnotify(void *mem, size_t new_size, size_t old_size)
+{
+    enum memop_type t;
+
+    if (new_size == 0)
+        t = MEMOP_TYPE_FREE;
+    else if (old_size == 0)
+        t = MEMOP_TYPE_MALLOC;
+    else
+        t = MEMOP_TYPE_REALLOC;
+
+    objspace_malloc_increase(&rb_objspace, mem, new_size, old_size, t);
+}
+
 void *
 ruby_xmalloc(size_t size)
 {

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -124,6 +124,7 @@ void *xcalloc(size_t,size_t) RUBY_ATTR_ALLOC_SIZE((1,2));
 void *xrealloc(void*,size_t) RUBY_ATTR_ALLOC_SIZE((2));
 void *xrealloc2(void*,size_t,size_t) RUBY_ATTR_ALLOC_SIZE((2,3));
 void xfree(void*);
+void ruby_memnotify(void*,size_t,size_t);
 
 #define STRINGIZE(expr) STRINGIZE0(expr)
 #ifndef STRINGIZE0


### PR DESCRIPTION
I wanna be able to add GC pressure to the Ruby GC so external libraries that don't use Ruby's memory allocator can trigger GC runs.

@charliesome @dbussink: How's this for size?
