### PR TITLE
require() resolution cache

### DIFF
--- a/load.c
+++ b/load.c
@@ -980,14 +980,14 @@ rb_require_safe(VALUE fname, int safe)
 	ipath = rb_str_encode_ospath(fname);
 	if (vm->require_cache.read && RSTRING_PTR(ipath)[0] != '/') {
 	    key = (st_data_t)RSTRING_PTR(ipath);
-	    if (st_delete(vm->require_cache.tbl, &key, &val)) {
+	    if (st_lookup(vm->require_cache.tbl, key, &val)) {
 		vals = (char *)val;
 		found = vals[0];
 		if (found) {
 		    /*fprintf(stderr, "FOUND '%s' => '%s'\n", (char *)key, vals);*/
 		    path = rb_str_new_cstr(vals+1);
+                    vals[1] = 0;
 		}
-		xfree(vals);
 	    } else {
 		found = search_required(ipath, &path, safe);
 		/*if (found && path)

--- a/load.c
+++ b/load.c
@@ -952,6 +952,9 @@ rb_require_safe(VALUE fname, int safe)
     } volatile saved;
     char *volatile ftptr = 0;
 
+    if (strncmp(StringValuePtr(fname), "enumerator", 11) == 0)
+	return Qfalse;
+
     if (RUBY_DTRACE_REQUIRE_ENTRY_ENABLED()) {
 	RUBY_DTRACE_REQUIRE_ENTRY(StringValuePtr(fname),
 				  rb_sourcefile(),

--- a/load.c
+++ b/load.c
@@ -1208,6 +1208,7 @@ require_cache_setup()
 	}
 	fclose(file);
     } else if ((env = getenv("REQUIRE_CACHE_WRITE"))) {
+	unsetenv("REQUIRE_CACHE_WRITE", "");
 	vm->require_cache.write = 1;
 	vm->require_cache.out = fopen(env, "w");
     }

--- a/load.c
+++ b/load.c
@@ -995,8 +995,8 @@ rb_require_safe(VALUE fname, int safe)
 	    }
 	} else {
 	    found = search_required(ipath, &path, safe);
-	    /*if (found && RSTRING_PTR(ipath)[0] != '/')
-		fprintf(stderr, "SEARCHING '%s'\n", RSTRING_PTR(ipath));*/
+	    /*if (found && path)
+		fprintf(stderr, "SEARCHING '%s' found '%s'\n", RSTRING_PTR(ipath), RSTRING_PTR(path));*/
 	}
 	if (vm->require_cache.write && RSTRING_PTR(ipath)[0] != '/' && (!found || (found && path))) {
 	    /*fprintf(stderr, "WRITING '%s' => '%s'\n", RSTRING_PTR(ipath), found ? RSTRING_PTR(path) : "");*/

--- a/load.c
+++ b/load.c
@@ -1195,7 +1195,11 @@ require_cache_setup()
     FILE *file;
     char *env, line1[PATH_MAX+3], line2[PATH_MAX+3];
 
-    if ((env = getenv("REQUIRE_CACHE_READ"))) {
+    if ((env = getenv("REQUIRE_CACHE_WRITE"))) {
+	unsetenv("REQUIRE_CACHE_WRITE", "");
+	vm->require_cache.write = 1;
+	vm->require_cache.out = fopen(env, "w");
+    } else if ((env = getenv("REQUIRE_CACHE_READ"))) {
 	file = fopen(env, "r");
 	if (!file) return;
 
@@ -1210,10 +1214,6 @@ require_cache_setup()
 	    st_insert(vm->require_cache.tbl, (st_data_t)ruby_strdup(line1), (st_data_t)ruby_strdup(line2));
 	}
 	fclose(file);
-    } else if ((env = getenv("REQUIRE_CACHE_WRITE"))) {
-	unsetenv("REQUIRE_CACHE_WRITE", "");
-	vm->require_cache.write = 1;
-	vm->require_cache.out = fopen(env, "w");
     }
 }
 

--- a/vm.c
+++ b/vm.c
@@ -1823,6 +1823,9 @@ ruby_vm_destruct(rb_vm_t *vm)
 #if defined(ENABLE_VM_OBJSPACE) && ENABLE_VM_OBJSPACE
 	struct rb_objspace *objspace = vm->objspace;
 #endif
+	if (vm->require_cache.write)
+	    fclose(vm->require_cache.out);
+
 	rb_gc_force_recycle(vm->self);
 	vm->main_thread = 0;
 	if (th) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -377,6 +377,12 @@ typedef struct rb_vm_struct {
     VALUE loaded_features_snapshot;
     struct st_table *loaded_features_index;
     struct st_table *loading_table;
+    struct {
+	unsigned int read:1;
+	struct st_table *tbl;
+	unsigned int write:1;
+	FILE *out;
+    } require_cache;
 
     /* signal */
     struct {


### PR DESCRIPTION
WIP proof-of-concept inspired by @charliesome's require caches

before:

```
$ RAILS_ENV=production strace -c -e trace=open bin/safe-ruby-quick -e' require "rubygems"; require "/data/github/branches/master/config/basic"; require "config/environment" '
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.000636           0    207409    193870 open

$ time env RAILS_ENV=production bin/safe-ruby-quick -e' require "rubygems"; require "/data/github/branches/master/config/basic"; require "config/environment" '
real    0m6.639s
user    0m5.784s
sys     0m0.812s
```

create cache:

```
$ RAILS_ENV=production REQUIRE_CACHE_WRITE=/tmp/require.cache bin/safe-ruby-quick -e' require "rubygems"; require "/data/github/branches/master/config/basic"; require "config/environment" '
```

after:

```
$ time env RAILS_ENV=production REQUIRE_CACHE_READ=/tmp/require.cache strace -c -e trace=open bin/safe-ruby-quick -e' require "rubygems"; require "/data/github/branches/master/config/basic"; require "config/environment" '
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.000074           0     26010     13072 open

$ time env RAILS_ENV=production REQUIRE_CACHE_READ=/tmp/require.cache bin/safe-ruby-quick -e' require "rubygems"; require "/data/github/branches/master/config/basic"; require "config/environment" '
real    0m5.996s
user    0m5.608s
sys     0m0.356s
```

There's some weird bug that's creating a corrupt cache which is why we're not yet hitting 0 open() errors yet. /cc @simonsj 
