### PR TITLE
[WIP] Add bytecode cache

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1560,15 +1560,22 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *anchor)
 			}
 		      case TS_CDHASH:
 			{
+			    int i;
 			    VALUE map = operands[j];
 			    struct cdhash_set_label_struct data;
-                            data.hash = map;
-                            data.pos = pos;
-                            data.len = len;
-			    rb_hash_foreach(map, cdhash_set_label_i, (VALUE)&data);
+			    data.hash = map;
+			    data.pos = pos;
+			    data.len = len;
+			    if (RB_TYPE_P(map, T_ARRAY)) {
+				data.hash = rb_hash_new();
+				for (i=0; i<RARRAY_LEN(map); i+=2)
+				    cdhash_set_label_i(RARRAY_AREF(map, i), RARRAY_AREF(map, i+1), &data);
+			    } else {
+				rb_hash_foreach(map, cdhash_set_label_i, (VALUE)&data);
+			    }
 
-			    hide_obj(map);
-			    generated_iseq[pos + 1 + j] = map;
+			    hide_obj(data.hash);
+			    generated_iseq[pos + 1 + j] = data.hash;
 			    break;
 			}
 		      case TS_LINDEX:

--- a/iseq.c
+++ b/iseq.c
@@ -1718,7 +1718,12 @@ iseq_data_to_ary(rb_iseq_t *iseq)
     for (i=0; i<iseq->local_table_size; i++) {
 	ID lid = iseq->local_table[i];
 	if (lid) {
-	    if (rb_id2str(lid)) rb_ary_push(locals, ID2SYM(lid));
+	    if (rb_id2str(lid)) {
+		rb_ary_push(locals, ID2SYM(lid));
+	    }
+	    else { /* hidden variable from id_internal() */
+		rb_ary_push(locals, ULONG2NUM(iseq->local_table_size-i+1));
+	    }
 	}
 	else {
 	    rb_ary_push(locals, ID2SYM(rb_intern("#arg_rest")));


### PR DESCRIPTION
Similar to rubinius' .rbc files and python's .pyc files

Initial spike just uses a marshaled iseq, but once this is fleshed out we could switch to a raw format that is faster to dump/load. A header at the top of the .rbi file that contains a checksum of the original source and a version number would be ideal as well.

cc @tenderlove @simonsj @charliesome @dbussink who I've discussed this with recently
