### PR TITLE
Add options to dump T_NONE objects and add page numbers

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -336,6 +336,7 @@ dump_object(VALUE obj, struct dump_config *dc)
 static int
 heap_i(void *vstart, void *vend, size_t stride, void *data)
 {
+    struct dump_config *dc = (struct dump_config *)data;
     VALUE v = (VALUE)vstart;
     for (; v != (VALUE)vend; v += stride) {
 	if (RBASIC(v)->flags)


### PR DESCRIPTION
This adds options to `dump_all` to dump `T_NONE` slots and add page numbers to each object.  Unfortunately, we can't assign page numbers based on the actual page where the object is stored because `rb_objspace_each_objects` doesn't expose the actual page pointer, though the page number is guaranteed to be correct _per dump_.  IOW, all objects with "page 25" in them are stored on the same page, but if you dump the heap a second time "page 25" may not be the same page as the previous dump.
