### PR TITLE
Stop reading past the end of `ivptr` array

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1605,7 +1605,7 @@ rb_ivar_count(VALUE obj)
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
 	if ((tbl = ROBJECT_IV_INDEX_TBL(obj)) != 0) {
-	    st_index_t i, count, num = tbl->num_entries;
+	    st_index_t i, count, num = ROBJECT_NUMIV(obj);
 	    const VALUE *const ivptr = ROBJECT_IVPTR(obj);
 	    for (i = count = 0; i < num; ++i) {
 		if (ivptr[i] != Qundef) {


### PR DESCRIPTION
If you have code like this:

```ruby
class A
  def initialize
    @a = nil
    @b = nil
    @c = nil
    @d = nil
    @e = nil
  end
end

x = A.new
y = x.clone
100.times { |z| x.instance_variable_set(:"@foo#{z}", nil) }
puts y.inspect
```

`x` and `y` will share `iv_index_tbl` hashes.  However, the size of the
hash will grow larger than the number of entries in `ivptr` in `y`.
Before this commit, `rb_ivar_count` would use the size of the hash to
determine how far to read in to the array, but this means that it could
read past the end of the array and cause the program to segv