### PR TITLE
ruby_setenv: Do not allow on multi-threaded programs

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3382,9 +3382,18 @@ check_envname(const char *name)
 }
 #endif
 
+static void
+check_running_threads(void)
+{
+    if (!rb_thread_alone())
+        rb_raise(rb_eRuntimeError, "cannot setenv() in a multi-threaded program");
+}
+
 void
 ruby_setenv(const char *name, const char *value)
 {
+    check_running_threads();
+
 #if defined(_WIN32)
 # if defined(MINGW_HAS_SECURE_API) || RUBY_MSVCRT_VERSION >= 80
 #   define HAVE__WPUTENV_S 1


### PR DESCRIPTION
:notes: Alright alright alright alright, here we come another day fresh off production, another reproducible MRI segfault. :notes:

Relevant C backtrace information:

```
-- Machine register context ------------------------------------------------
 RIP: 0x00007ffb8ee52b6c RBP: 0x0000000000000001 RSP: 0x00007ffb77a252e0
 RAX: 0x0000000000000000 RBX: 0x00007ffb96f60338 RCX: 0x0000000000000052
 RDX: 0x0000000000000006 RDI: 0x00007ffb8ef92f3b RSI: 0x00000000fffff800
  R8: 0x0000000000000001  R9: 0x00000000ffffffff R10: 0x0000000000000000
 R11: 0x0000000000000206 R12: 0x0000000000004552 R13: 0x00007ffb8ef92f3d
 R14: 0x0000000000000009 R15: 0x000000000000000b EFL: 0x0000000000010202

-- C level backtrace information -------------------------------------------
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(rb_vm_bugreport+0x5c7) [0x7ffb906b02c7] vm_dump.c:679
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(rb_bug_context+0xd7) [0x7ffb906a6f27] error.c:426
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(sigsegv+0x3e) [0x7ffb905be85e] signal.c:907
/lib/x86_64-linux-gnu/libpthread.so.0 [0x7ffb8fd94cb0]
/lib/x86_64-linux-gnu/libc.so.6(getenv+0x9c) [0x7ffb8ee52b6c] getenv.c:81
/lib/x86_64-linux-gnu/libc.so.6(__res_vinit+0x735) [0x7ffb8ef1b205] res_init.c:471
/lib/x86_64-linux-gnu/libc.so.6(__res_maybe_init+0x125) [0x7ffb8ef1ca85] res_libc.c:125
/lib/x86_64-linux-gnu/libc.so.6(gaih_inet+0x5b5) [0x7ffb8eee2755] ../sysdeps/posix/getaddrinfo.c:821
/lib/x86_64-linux-gnu/libc.so.6(getaddrinfo+0xdc) [0x7ffb8eee60dc] ../sysdeps/posix/getaddrinfo.c:2374
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/lib/ruby/2.4.0/x86_64-linux/socket.so(nogvl_getaddrinfo+0x18) [0x7ffb8d0c4138] raddrinfo.c:190
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(rb_thread_call_without_gvl+0x5a) [0x7ffb905f359a] thread.c:1294
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/lib/ruby/2.4.0/x86_64-linux/socket.so(rb_getaddrinfo+0xa5) [0x7ffb8d0c5105] raddrinfo.c:309
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/lib/ruby/2.4.0/x86_64-linux/socket.so(rsock_getaddrinfo+0x107) [0x7ffb8d0c61c7] raddrinfo.c:522
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/lib/ruby/2.4.0/x86_64-linux/socket.so(rsock_addrinfo+0x31) [0x7ffb8d0c6b31] raddrinfo.c:555
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/lib/ruby/2.4.0/x86_64-linux/socket.so(sock_s_gethostbyname+0x1e) [0x7ffb8d0bacee] socket.c:994
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_call_cfunc_with_frame.isra.96+0xe2) [0x7ffb9061e7a2] vm_insnhelper.c:1752
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_call_method_each_type+0x110) [0x7ffb9062cbd0] vm_insnhelper.c:1847
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_call_general+0xab) [0x7ffb9062d77b] vm_insnhelper.c:2294
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_exec_core+0x2688) [0x7ffb90625e68] insns.def:1066
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_exec+0x81) [0x7ffb9062b6b1] vm.c:1712
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(invoke_iseq_block_from_c+0x229) [0x7ffb9062c239] vm.c:969
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_invoke_proc+0x100) [0x7ffb9062c650] vm.c:1086
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_call0_body+0x4c5) [0x7ffb9062e175] vm_eval.c:235
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(rb_call0+0x1b1) [0x7ffb9062ec81] vm_eval.c:61
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(rb_funcall+0xce) [0x7ffb9062f2ce] vm_eval.c:628
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(rb_hash_aref+0x4b) [0x7ffb90503c3b] hash.c:850
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_exec_core+0x3fce) [0x7ffb906277ae] insns.def:1826
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_exec+0x81) [0x7ffb9062b6b1] vm.c:1712
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(invoke_iseq_block_from_c+0x229) [0x7ffb9062c239] vm.c:969
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(vm_invoke_proc+0x100) [0x7ffb9062c650] vm.c:1086
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(thread_start_func_2+0x5bc) [0x7ffb905f269c] thread.c:585
/var/lib/jenkins/workspace/github/vendor/ruby/d4bb726b713658f56e630b6cf817a0155b6f390e/bin/ruby(thread_start_func_1+0xd1) [0x7ffb905f2b81] thread_pthread.c:887
/lib/x86_64-linux-gnu/libpthread.so.0(start_thread+0xda) [0x7ffb8fd8ce9a] pthread_create.c:308
/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7ffb8ef0b36d] ../sysdeps/unix/sysv/linux/x86_64/clone.S:112
```

The actual Ruby code causing the crash is not relevant. There are no C extensions involved nor potential VM bugs.

The segmentation fault is caused when `socket.c` in the VM code tries to resolve an address (`getaddrinfo`) during a test run. The steps are as follows:

1. The GVL is released
2. The VM calls into `glibc` using `getaddrinfo`
3. This is the first time that the Ruby process is attempting to do address resolution
4. `glibc` attempts to initialize the DNS resolver (`res_init.c:471`)
5. As part of the resolution process, the per-process resolution configuration is loaded from the environment variable `RES_OPTIONS` (see: http://man7.org/linux/man-pages/man5/resolv.conf.5.html)
6. `glibc` segfaults when trying to read the environment variable

What does it take to make `getenv("RES_OPTIONS")` segfault? We can find out from the core dump.

Here's the relevant code from `getenv.c` in `glibc` 2.13:

```
      for (ep = __environ; *ep != NULL; ++ep)
	{
	  uint16_t ep_start = *(uint16_t *) *ep;
	  if (name_start == ep_start && !strncmp (*ep + 2, name, len)
	      && (*ep)[len + 2] == '=')
	    return &(*ep)[len + 3];
	}
```

And here's a GDB trace:

```
(gdb) p __environ
$27 = (char **) 0x7ffb96f60000
(gdb) p ep
$28 = (char **) 0x7ffb96f60338
(gdb) p *ep
$32 = 0x1 <Address 0x1 out of bounds>
(gdb) p (ep - __environ)
$29 = 103
(gdb) p __environ[97]
$30 = 0x7ffbaa220d00 "GATEWAY_PORT=1520"
(gdb) p __environ[98]
$31 = 0x0
```

To note: currently `ep` points at `__environ + 103`, and its contents are clearly bogus. We can see however that the `NULL` pointer at the end of `__environ` is at `__environ + 98`. How did this get past the `NULL` check?

Easy. Somebody modified `__environ` by calling `setenv` while we were reading it. It's a data race.

Let's see what the `glibc` manual has to say about this:

> Modifications of environment variables are not allowed in multi-threaded programs.

Oh shit that's not really ambiguous at all. MRI's `ruby_setenv` is highly unsafe. Hence, this PR proposes the only reasonable solution to the issue: disable `ruby_setenv` if there's more than one Ruby thread in the current process.

### FAQ

1. **Could we instead add exclusive locking around `ruby_setenv` and `ruby_getenv` to serialize away the data race?**

	No. As you can see in this example, the race happens in a `getenv` call -- one that was not even explicit as it comes from inside of `glibc` and very much outside of GVL locking.
	
2. **Should we be checking for *any* existing `pthreads` instead of Ruby threads?**

	Ideally, yes. In practice, any `pthreads` not spawned by MRI itself are not its responsibility. This patch makes MRI posix compliant -- if a C extension is broken that's not the fault of the VM.
	
3. **Is this going to break real-world applications?**

	Yes! That's the point. The applications were broken to begin with. This patch will shed light on their bullshit. And show us an actual Ruby backtrace so we can fix the apps.
	
cc @tenderlove @github/mri-hackers @github/platform-systems @eileencodes