### PR TITLE
Backport r60182 to fix High Sierra issues

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -4142,8 +4142,8 @@ AS_CASE(["$target_os"],
 	],
     [darwin*], [
 	RUBY_APPEND_OPTION(CFLAGS, -pipe)
-	RUBY_APPEND_OPTION(XLDFLAGS, [-framework CoreFoundation])
-	RUBY_APPEND_OPTION(LIBRUBYARG_STATIC, [-framework CoreFoundation])
+	RUBY_APPEND_OPTION(XLDFLAGS, [-framework Foundation])
+	RUBY_APPEND_OPTION(LIBRUBYARG_STATIC, [-framework Foundation])
 	],
     [osf*], [
 	if test "$GCC" != "yes" ; then


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/14009 - this is in trunk, and will be backported to the 2.4 branch. This works around a change in macOS 10.13 which affects forking, and prevents the need to work around that issue at the application level.