### PR TITLE
Mark objects in iseqs by disassembly

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -538,7 +538,7 @@ un-runnable:
 mjit_config.h:
 	$(ECHO) making $@
 	@{ \
-	$(Q:@=:) set -x; \
+	test "$(Q)" = @ || set -x; \
 	echo '#ifndef RUBY_MJIT_CONFIG_H'; \
 	echo '#define RUBY_MJIT_CONFIG_H 1'; \
 	\

--- a/benchmark/bm_array_values_at_int.rb
+++ b/benchmark/bm_array_values_at_int.rb
@@ -1,0 +1,2 @@
+ary = Array.new(10000) {|i| i}
+100000.times { ary.values_at(500) }

--- a/benchmark/bm_array_values_at_range.rb
+++ b/benchmark/bm_array_values_at_range.rb
@@ -1,0 +1,2 @@
+ary = Array.new(10000) {|i| i}
+100000.times { ary.values_at(1..2000) }

--- a/compile.c
+++ b/compile.c
@@ -2209,11 +2209,6 @@ iseq_set_exception_table(rb_iseq_t *iseq)
 	    entry->end = label_get_position((LABEL *)(ptr[2] & ~1));
 	    entry->iseq = (rb_iseq_t *)ptr[3];
 
-	    /* register iseq as mark object */
-	    if (entry->iseq != 0) {
-		iseq_add_mark_object(iseq, (VALUE)entry->iseq);
-	    }
-
 	    /* stack depth */
 	    if (ptr[4]) {
 		LABEL *lobj = (LABEL *)(ptr[4] & ~1);

--- a/compile.c
+++ b/compile.c
@@ -563,15 +563,6 @@ APPEND_ELEM(ISEQ_ARG_DECLARE LINK_ANCHOR *const anchor, LINK_ELEMENT *before, LI
 #endif
 
 static int
-iseq_add_mark_object(const rb_iseq_t *iseq, VALUE v)
-{
-    if (!SPECIAL_CONST_P(v)) {
-	rb_iseq_add_mark_object(iseq, v);
-    }
-    return COMPILE_OK;
-}
-
-static int
 iseq_add_mark_object_compile_time(const rb_iseq_t *iseq, VALUE v)
 {
     if (!SPECIAL_CONST_P(v)) {
@@ -1235,7 +1226,7 @@ new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
 				    rb_iseq_path(iseq), rb_iseq_realpath(iseq),
 				    INT2FIX(line_no), parent, type, ISEQ_COMPILE_DATA(iseq)->option);
     debugs("[new_child_iseq]< ---------------------------------------\n");
-    iseq_add_mark_object(iseq, (VALUE)ret_iseq);
+    iseq_add_mark_object_compile_time(iseq, (VALUE)ret_iseq);
     return ret_iseq;
 }
 
@@ -1250,7 +1241,7 @@ new_child_iseq_ifunc(rb_iseq_t *iseq, const struct vm_ifunc *ifunc,
 				 rb_iseq_path(iseq), rb_iseq_realpath(iseq),
 				 INT2FIX(line_no), parent, type, ISEQ_COMPILE_DATA(iseq)->option);
     debugs("[new_child_iseq_ifunc]< ---------------------------------------\n");
-    iseq_add_mark_object(iseq, (VALUE)ret_iseq);
+    iseq_add_mark_object_compile_time(iseq, (VALUE)ret_iseq);
     return ret_iseq;
 }
 
@@ -1501,7 +1492,6 @@ iseq_set_arguments_keywords(rb_iseq_t *iseq, LINK_ANCHOR *const optargs,
 	    switch (nd_type(val_node)) {
 	      case NODE_LIT:
 		dv = val_node->nd_lit;
-		iseq_add_mark_object(iseq, dv);
 		break;
 	      case NODE_NIL:
 		dv = Qnil;
@@ -2044,7 +2034,6 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			    VALUE v = operands[j];
 			    generated_iseq[code_index + 1 + j] = v;
 			    /* to mark ruby object */
-			    iseq_add_mark_object(iseq, v);
 			    break;
 			}
 		      case TS_IC: /* inline cache */
@@ -4822,7 +4811,6 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
     }
 
     if (only_special_literals) {
-	iseq_add_mark_object(iseq, literals);
 
 	ADD_INSN(ret, nd_line(orig_node), dup);
 	ADD_INSN2(ret, nd_line(orig_node), opt_case_dispatch, literals, elselabel);
@@ -7538,7 +7526,6 @@ iseq_build_load_iseq(const rb_iseq_t *iseq, VALUE op)
     }
 
     loaded_iseq = rb_iseqw_to_iseq(iseqw);
-    iseq_add_mark_object(iseq, (VALUE)loaded_iseq);
     return loaded_iseq;
 }
 
@@ -7669,7 +7656,6 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
 			break;
 		      case TS_VALUE:
 			argv[j] = op;
-			iseq_add_mark_object(iseq, op);
 			break;
 		      case TS_ISEQ:
 			{
@@ -7716,7 +7702,6 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
 			    }
 			    RB_GC_GUARD(op);
 			    argv[j] = map;
-			    rb_iseq_add_mark_object(iseq, map);
 			}
 			break;
 		      case TS_FUNCPTR:
@@ -9320,7 +9305,6 @@ ibf_load_object(const struct ibf_load *load, VALUE object_index)
 
 	    rb_ary_store(load->obj_list, (long)object_index, obj);
 	}
-	iseq_add_mark_object(load->iseq, obj);
 	return obj;
     }
 }
@@ -9507,9 +9491,6 @@ ibf_load_iseq(const struct ibf_load *load, const rb_iseq_t *index_iseq)
 	    ibf_load_iseq_complete(iseq);
 #endif /* !USE_LAZY_LOAD */
 
-	    if (load->iseq) {
-		iseq_add_mark_object(load->iseq, (VALUE)iseq);
-	    }
 	    return iseq;
 	}
     }

--- a/compile.c
+++ b/compile.c
@@ -8644,7 +8644,8 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     dump_body.is_entries =           NULL;
     dump_body.ci_entries =           ibf_dump_ci_entries(dump, iseq);
     dump_body.cc_entries =           NULL;
-    dump_body.mark_ary =             ISEQ_FLIP_CNT(iseq);
+    dump_body.variable.coverage      = Qnil;
+    dump_body.variable.original_iseq = Qnil;
 
     return ibf_dump_write(dump, &dump_body, sizeof(dump_body));
 }
@@ -8676,7 +8677,7 @@ ibf_load_iseq_each(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t of
     load_body->ci_kw_size = body->ci_kw_size;
     load_body->insns_info.size = body->insns_info.size;
 
-    RB_OBJ_WRITE(iseq, &load_body->mark_ary, iseq_mark_ary_create((int)body->mark_ary));
+    iseq_mark_ary_create(iseq, (int)body->variable.flip_count);
 
     {
 	VALUE realpath = Qnil, path = ibf_load_object(load, body->location.pathobj);

--- a/compile.c
+++ b/compile.c
@@ -2018,6 +2018,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			    rb_hash_rehash(map);
 			    freeze_hide_obj(map);
 			    generated_iseq[code_index + 1 + j] = map;
+			    FL_SET(iseq, ISEQ_MARKABLE_ISEQ);
 			    break;
 			}
 		      case TS_LINDEX:
@@ -2028,6 +2029,9 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			{
 			    VALUE v = operands[j];
 			    generated_iseq[code_index + 1 + j] = v;
+			    if (!SPECIAL_CONST_P(v)) {
+				FL_SET(iseq, ISEQ_MARKABLE_ISEQ);
+			    }
 			    break;
 			}
 		      case TS_VALUE:	/* VALUE */
@@ -2035,6 +2039,9 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			    VALUE v = operands[j];
 			    generated_iseq[code_index + 1 + j] = v;
 			    /* to mark ruby object */
+			    if (!SPECIAL_CONST_P(v)) {
+				FL_SET(iseq, ISEQ_MARKABLE_ISEQ);
+			    }
 			    break;
 			}
 		      case TS_IC: /* inline cache */
@@ -2045,6 +2052,9 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 				rb_bug("iseq_set_sequence: ic_index overflow: index: %d, size: %d", ic_index, iseq->body->is_size);
 			    }
 			    generated_iseq[code_index + 1 + j] = (VALUE)ic;
+			    if (BIN(once) == insn || BIN(trace_once) == insn) {
+				FL_SET(iseq, ISEQ_MARKABLE_ISEQ);
+			    }
 			    break;
 			}
 		      case TS_CALLINFO: /* call info */

--- a/compile.c
+++ b/compile.c
@@ -740,6 +740,7 @@ rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 	encoded[i] = (VALUE)table[insn];
 	i += len;
     }
+    FL_SET(iseq, ISEQ_TRANSLATED);
 #endif
     return COMPILE_OK;
 }

--- a/compile.c
+++ b/compile.c
@@ -4811,6 +4811,7 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
     }
 
     if (only_special_literals) {
+	iseq_add_mark_object_compile_time(iseq, literals);
 
 	ADD_INSN(ret, nd_line(orig_node), dup);
 	ADD_INSN2(ret, nd_line(orig_node), opt_case_dispatch, literals, elselabel);

--- a/compile.c
+++ b/compile.c
@@ -2851,11 +2851,11 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 	struct rb_call_info *ci = (struct rb_call_info *)OPERAND_AT(niobj, 0);
 	/*
 	 *  freezestring debug_info
-	 *  send <:+@, 0, ARG_SIMPLE>
+	 *  send <:+@, 0, ARG_SIMPLE>  # :-@, too
 	 * =>
-	 *  send <:+@, 0, ARG_SIMPLE>
+	 *  send <:+@, 0, ARG_SIMPLE>  # :-@, too
 	 */
-	if (ci->mid == idUPlus &&
+	if ((ci->mid == idUPlus || ci->mid == idUMinus) &&
 	    (ci->flag & VM_CALL_ARGS_SIMPLE) &&
 	    ci->orig_argc == 0) {
 	    ELEM_REMOVE(list);

--- a/configure.ac
+++ b/configure.ac
@@ -2256,7 +2256,7 @@ AS_IF([test "${universal_binary-no}" = yes ], [
 
 AS_IF([test x"$enable_pthread" = xyes], [
     for pthread_lib in thr pthread pthreads c c_r root; do
-	AC_CHECK_LIB($pthread_lib, pthread_kill,
+	AC_CHECK_LIB($pthread_lib, pthread_create,
 		     rb_with_pthread=yes, rb_with_pthread=no)
 	AS_IF([test "$rb_with_pthread" = "yes"], [ break; fi
     done

--- a/configure.ac
+++ b/configure.ac
@@ -2290,7 +2290,7 @@ AS_IF([test x"$enable_pthread" = xyes], [
 	AC_DEFINE(NON_SCALAR_THREAD_ID)
     ])
     AC_CHECK_FUNCS(sched_yield pthread_attr_setinheritsched \
-	pthread_attr_get_np pthread_attr_getstack \
+	pthread_attr_get_np pthread_attr_getstack pthread_attr_getguardsize \
 	pthread_get_stackaddr_np pthread_get_stacksize_np \
 	thr_stksegment pthread_stackseg_np pthread_getthrds_np \
 	pthread_condattr_setclock \

--- a/gc.c
+++ b/gc.c
@@ -3996,6 +3996,11 @@ init_mark_stack(mark_stack_t *stack)
 #define STACK_END (ec->machine.stack_end)
 #define STACK_LEVEL_MAX (ec->machine.stack_maxsize/sizeof(VALUE))
 
+#ifdef __EMSCRIPTEN__
+#undef STACK_GROW_DIRECTION
+#define STACK_GROW_DIRECTION 1
+#endif
+
 #if STACK_GROW_DIRECTION < 0
 # define STACK_LENGTH  (size_t)(STACK_START - STACK_END)
 #elif STACK_GROW_DIRECTION > 0

--- a/insns.def
+++ b/insns.def
@@ -971,11 +971,11 @@ setinlinecache
 /* run iseq only once */
 DEFINE_INSN
 once
-(ISEQ iseq, IC ic)
+(ISEQ iseq, ISE ise)
 ()
 (VALUE val)
 {
-    val = vm_once_dispatch(ec, iseq, ic);
+    val = vm_once_dispatch(ec, iseq, ise);
 }
 
 /* case dispatcher, jump by table if possible */

--- a/iseq.c
+++ b/iseq.c
@@ -166,7 +166,7 @@ iseq_extract_values(const VALUE *code, size_t pos, iseq_value_itr_t * func, void
     return len;
 }
 
-void
+static void
 rb_iseq_each_value(const rb_iseq_t *iseq, iseq_value_itr_t * func, void *data)
 {
     unsigned int size;
@@ -184,7 +184,7 @@ rb_iseq_each_value(const rb_iseq_t *iseq, iseq_value_itr_t * func, void *data)
 static void
 each_insn_value(void *ctx, VALUE obj)
 {
-    return rb_gc_mark(obj);
+    rb_gc_mark(obj);
 }
 
 void

--- a/iseq.c
+++ b/iseq.c
@@ -128,7 +128,20 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 	rb_gc_mark(body->location.base_label);
 	rb_gc_mark(body->location.pathobj);
 	RUBY_MARK_UNLESS_NULL((VALUE)body->parent_iseq);
+
+	if (body->catch_table) {
+	    const struct iseq_catch_table *table = body->catch_table;
+	    unsigned int i;
+	    for(i = 0; i < table->size; i++) {
+		const struct iseq_catch_table_entry *entry;
+		entry = &table->entries[i];
+		if (entry->iseq) {
+		    rb_gc_mark((VALUE)entry->iseq);
+		}
+	    }
+	}
     }
+
 
     if (FL_TEST(iseq, ISEQ_NOT_LOADED_YET)) {
 	rb_gc_mark(iseq->aux.loader.obj);

--- a/iseq.c
+++ b/iseq.c
@@ -217,7 +217,10 @@ rb_iseq_mark(const rb_iseq_t *iseq)
     if (iseq->body) {
 	const struct rb_iseq_constant_body *body = iseq->body;
 
-	rb_iseq_each_value(iseq, each_insn_value, NULL);
+	if(FL_TEST(iseq, ISEQ_MARKABLE_ISEQ)) {
+	    rb_iseq_each_value(iseq, each_insn_value, NULL);
+	}
+
 	rb_gc_mark(body->variable.coverage);
 	rb_gc_mark(body->variable.original_iseq);
 	rb_gc_mark(body->location.label);

--- a/iseq.c
+++ b/iseq.c
@@ -117,7 +117,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
 
 #if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
 static int
-rb_vm_insn_addr2insn2(const void *addr) /* cold path */
+rb_vm_insn_addr2insn2(const void *addr)
 {
     int insn;
     const void * const *table = rb_vm_get_insns_address_table();
@@ -147,15 +147,17 @@ iseq_extract_values(const VALUE *code, size_t pos, iseq_value_itr_t * func, void
 
     for (op_no = 0; types[op_no]; op_no++) {
 	char type = types[op_no];
-	VALUE op = code[pos + op_no + 1];
 	switch (type) {
 	    case TS_CDHASH:
 	    case TS_ISEQ:
 	    case TS_VALUE:
-		if (!SPECIAL_CONST_P(op)) {
-		    func(data, op);
+		{
+		    VALUE op = code[pos + op_no + 1];
+		    if (!SPECIAL_CONST_P(op)) {
+			func(data, op);
+		    }
+		    break;
 		}
-		break;
 	    default:
 		break;
 	}

--- a/iseq.c
+++ b/iseq.c
@@ -218,7 +218,8 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 	const struct rb_iseq_constant_body *body = iseq->body;
 
 	rb_iseq_each_value(iseq, each_insn_value, NULL);
-	RUBY_MARK_UNLESS_NULL(body->mark_ary);
+	rb_gc_mark(body->variable.coverage);
+	rb_gc_mark(body->variable.original_iseq);
 	rb_gc_mark(body->location.label);
 	rb_gc_mark(body->location.base_label);
 	rb_gc_mark(body->location.pathobj);
@@ -427,7 +428,7 @@ prepare_iseq_build(rb_iseq_t *iseq,
     if (iseq != iseq->body->local_iseq) {
 	RB_OBJ_WRITE(iseq, &iseq->body->location.base_label, iseq->body->local_iseq->body->location.label);
     }
-    RB_OBJ_WRITE(iseq, &iseq->body->mark_ary, iseq_mark_ary_create(0));
+    iseq_mark_ary_create(iseq, 0);
 
     ISEQ_COMPILE_DATA_ALLOC(iseq);
     RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->err_info, err_info);

--- a/iseq.c
+++ b/iseq.c
@@ -115,6 +115,76 @@ rb_iseq_free(const rb_iseq_t *iseq)
     RUBY_FREE_LEAVE("iseq");
 }
 
+#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
+static int
+rb_vm_insn_addr2insn2(const void *addr) /* cold path */
+{
+    int insn;
+    const void * const *table = rb_vm_get_insns_address_table();
+
+    for (insn = 0; insn < VM_INSTRUCTION_SIZE; insn++) {
+	if (table[insn] == addr) {
+	    return insn;
+	}
+    }
+    rb_bug("rb_vm_insn_addr2insn: invalid insn address: %p", addr);
+}
+#endif
+
+typedef void iseq_value_itr_t(void *ctx, VALUE obj);
+
+static int
+iseq_extract_values(const VALUE *code, size_t pos, iseq_value_itr_t * func, void *data)
+{
+#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
+    VALUE insn = rb_vm_insn_addr2insn2((void *)code[pos]);
+#else
+    VALUE insn = code[pos];
+#endif
+    int len = insn_len(insn);
+    int op_no;
+    const char *types = insn_op_types(insn);
+
+    for (op_no = 0; types[op_no]; op_no++) {
+	char type = types[op_no];
+	VALUE op = code[pos + op_no + 1];
+	switch (type) {
+	    case TS_CDHASH:
+	    case TS_ISEQ:
+	    case TS_VALUE:
+		if (!SPECIAL_CONST_P(op)) {
+		    func(data, op);
+		}
+		break;
+	    default:
+		break;
+	}
+    }
+
+    return len;
+}
+
+void
+rb_iseq_each_value(const rb_iseq_t *iseq, iseq_value_itr_t * func, void *data)
+{
+    unsigned int size;
+    const VALUE *code;
+    size_t n;
+
+    size = iseq->body->iseq_size;
+    code = iseq->body->iseq_encoded;
+
+    for (n = 0; n < size;) {
+	n += iseq_extract_values(code, n, func, data);
+    }
+}
+
+static void
+each_insn_value(void *ctx, VALUE obj)
+{
+    return rb_gc_mark(obj);
+}
+
 void
 rb_iseq_mark(const rb_iseq_t *iseq)
 {
@@ -123,6 +193,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
     if (iseq->body) {
 	const struct rb_iseq_constant_body *body = iseq->body;
 
+	rb_iseq_each_value(iseq, each_insn_value, NULL);
 	RUBY_MARK_UNLESS_NULL(body->mark_ary);
 	rb_gc_mark(body->location.label);
 	rb_gc_mark(body->location.base_label);

--- a/iseq.c
+++ b/iseq.c
@@ -161,6 +161,14 @@ iseq_extract_values(const VALUE *code, size_t pos, iseq_value_itr_t * func, void
 		    }
 		    break;
 		}
+	    case TS_IC:
+		if (BIN(once) == insn || BIN(trace_once) == insn) {
+		    union iseq_inline_storage_entry *const is = (union iseq_inline_storage_entry *)code[pos + op_no + 1];
+		    if (is->once.value) {
+			func(data, is->once.value);
+		    }
+		}
+		break;
 	    default:
 		break;
 	}
@@ -397,13 +405,6 @@ set_relation(rb_iseq_t *iseq, const rb_iseq_t *piseq)
     if (type == ISEQ_TYPE_MAIN) {
 	iseq->body->local_iseq = iseq;
     }
-}
-
-void
-rb_iseq_add_mark_object(const rb_iseq_t *iseq, VALUE obj)
-{
-    /* TODO: check dedup */
-    rb_ary_push(ISEQ_MARK_ARY(iseq), obj);
 }
 
 static VALUE

--- a/iseq.c
+++ b/iseq.c
@@ -161,14 +161,14 @@ iseq_extract_values(const VALUE *code, size_t pos, iseq_value_itr_t * func, void
 		    }
 		    break;
 		}
-	    case TS_IC:
-		if (BIN(once) == insn || BIN(trace_once) == insn) {
+	    case TS_ISE:
+		{
 		    union iseq_inline_storage_entry *const is = (union iseq_inline_storage_entry *)code[pos + op_no + 1];
 		    if (is->once.value) {
 			func(data, is->once.value);
 		    }
+		    break;
 		}
-		break;
 	    default:
 		break;
 	}
@@ -1717,6 +1717,7 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
 	break;
 
       case TS_IC:
+      case TS_ISE:
 	ret = rb_sprintf("<is:%"PRIdPTRDIFF">", (union iseq_inline_storage_entry *)op - iseq->body->is_entries);
 	break;
 
@@ -2460,6 +2461,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 		}
 		break;
 	      case TS_IC:
+	      case TS_ISE:
 		{
 		    union iseq_inline_storage_entry *is = (union iseq_inline_storage_entry *)*seq;
 		    rb_ary_push(ary, INT2FIX(is - iseq->body->is_entries));

--- a/iseq.h
+++ b/iseq.h
@@ -94,6 +94,7 @@ ISEQ_ORIGINAL_ISEQ_ALLOC(const rb_iseq_t *iseq, long size)
 
 #define ISEQ_NOT_LOADED_YET   IMEMO_FL_USER1
 #define ISEQ_USE_COMPILE_DATA IMEMO_FL_USER2
+#define ISEQ_TRANSLATED       IMEMO_FL_USER3
 
 struct iseq_compile_data {
     /* GC is needed */

--- a/iseq.h
+++ b/iseq.h
@@ -84,6 +84,7 @@ ISEQ_ORIGINAL_ISEQ_ALLOC(const rb_iseq_t *iseq, long size)
 #define ISEQ_NOT_LOADED_YET   IMEMO_FL_USER1
 #define ISEQ_USE_COMPILE_DATA IMEMO_FL_USER2
 #define ISEQ_TRANSLATED       IMEMO_FL_USER3
+#define ISEQ_MARKABLE_ISEQ    IMEMO_FL_USER4
 
 struct iseq_compile_data {
     /* GC is needed */

--- a/iseq.h
+++ b/iseq.h
@@ -28,44 +28,33 @@ rb_call_info_kw_arg_bytes(int keyword_len)
     return sizeof(struct rb_call_info_kw_arg) + sizeof(VALUE) * (keyword_len - 1);
 }
 
-enum iseq_mark_ary_index {
-    ISEQ_MARK_ARY_COVERAGE,
-    ISEQ_MARK_ARY_FLIP_CNT,
-    ISEQ_MARK_ARY_ORIGINAL_ISEQ,
-    ISEQ_MARK_ARY_INITIAL_SIZE
-};
-
-static inline VALUE
-iseq_mark_ary_create(int flip_cnt)
+static inline void
+iseq_mark_ary_create(rb_iseq_t *iseq, int flip_cnt)
 {
-    VALUE ary = rb_ary_tmp_new(ISEQ_MARK_ARY_INITIAL_SIZE);
-    rb_ary_push(ary, Qnil);              /* ISEQ_MARK_ARY_COVERAGE */
-    rb_ary_push(ary, INT2FIX(flip_cnt)); /* ISEQ_MARK_ARY_FLIP_CNT */
-    rb_ary_push(ary, Qnil);              /* ISEQ_MARK_ARY_ORIGINAL_ISEQ */
-    return ary;
+    RB_OBJ_WRITE(iseq, &iseq->body->variable.coverage, Qnil);
+    RB_OBJ_WRITE(iseq, &iseq->body->variable.original_iseq, Qnil);
+    iseq->body->variable.flip_count = flip_cnt;
 }
 
-#define ISEQ_MARK_ARY(iseq)           (iseq)->body->mark_ary
-
-#define ISEQ_COVERAGE(iseq)           RARRAY_AREF(ISEQ_MARK_ARY(iseq), ISEQ_MARK_ARY_COVERAGE)
-#define ISEQ_COVERAGE_SET(iseq, cov)  RARRAY_ASET(ISEQ_MARK_ARY(iseq), ISEQ_MARK_ARY_COVERAGE, cov)
+#define ISEQ_COVERAGE(iseq)           iseq->body->variable.coverage
+#define ISEQ_COVERAGE_SET(iseq, cov)  RB_OBJ_WRITE(iseq, &iseq->body->variable.coverage, cov)
 #define ISEQ_LINE_COVERAGE(iseq)      RARRAY_AREF(ISEQ_COVERAGE(iseq), COVERAGE_INDEX_LINES)
 #define ISEQ_BRANCH_COVERAGE(iseq)    RARRAY_AREF(ISEQ_COVERAGE(iseq), COVERAGE_INDEX_BRANCHES)
 
-#define ISEQ_FLIP_CNT(iseq) FIX2INT(RARRAY_AREF(ISEQ_MARK_ARY(iseq), ISEQ_MARK_ARY_FLIP_CNT))
+#define ISEQ_FLIP_CNT(iseq) (iseq)->body->variable.flip_count
 
 static inline int
 ISEQ_FLIP_CNT_INCREMENT(const rb_iseq_t *iseq)
 {
-    int cnt = ISEQ_FLIP_CNT(iseq);
-    RARRAY_ASET(ISEQ_MARK_ARY(iseq), ISEQ_MARK_ARY_FLIP_CNT, INT2FIX(cnt+1));
+    int cnt = iseq->body->variable.flip_count;
+    iseq->body->variable.flip_count += 1;
     return cnt;
 }
 
 static inline VALUE *
 ISEQ_ORIGINAL_ISEQ(const rb_iseq_t *iseq)
 {
-    VALUE str = RARRAY_AREF(ISEQ_MARK_ARY(iseq), ISEQ_MARK_ARY_ORIGINAL_ISEQ);
+    VALUE str = iseq->body->variable.original_iseq;
     if (RTEST(str)) return (VALUE *)RSTRING_PTR(str);
     return NULL;
 }
@@ -73,14 +62,14 @@ ISEQ_ORIGINAL_ISEQ(const rb_iseq_t *iseq)
 static inline void
 ISEQ_ORIGINAL_ISEQ_CLEAR(const rb_iseq_t *iseq)
 {
-    RARRAY_ASET(ISEQ_MARK_ARY(iseq), ISEQ_MARK_ARY_ORIGINAL_ISEQ, Qnil);
+    RB_OBJ_WRITE(iseq, &iseq->body->variable.original_iseq, Qnil);
 }
 
 static inline VALUE *
 ISEQ_ORIGINAL_ISEQ_ALLOC(const rb_iseq_t *iseq, long size)
 {
     VALUE str = rb_str_tmp_new(size * sizeof(VALUE));
-    RARRAY_ASET(ISEQ_MARK_ARY(iseq), ISEQ_MARK_ARY_ORIGINAL_ISEQ, str);
+    RB_OBJ_WRITE(iseq, &iseq->body->variable.original_iseq, str);
     return (VALUE *)RSTRING_PTR(str);
 }
 

--- a/iseq.h
+++ b/iseq.h
@@ -174,7 +174,6 @@ void rb_iseq_build_from_ary(rb_iseq_t *iseq, VALUE misc,
 			    VALUE exception, VALUE body);
 
 /* iseq.c */
-void rb_iseq_add_mark_object(const rb_iseq_t *iseq, VALUE obj);
 VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);
 VALUE rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc);
 struct st_table *ruby_insn_make_insn_table(void);

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -212,6 +212,7 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
       s.oflush # oflush may be issued after "a" is already sent.
       s.print "b"
       s.flush
+      sleep 0.1
       assert_include(["b", "ab"], m.readpartial(10))
     }
   end

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -568,6 +568,21 @@ class TestRubyOptimization < Test::Unit::TestCase
     end
   end
 
+  def test_peephole_dstr
+    code = "#{<<~'begin;'}\n#{<<~'end;'}"
+    begin;
+      exp = (-'a').object_id
+      z = 'a'
+      exp == (-"#{z}").object_id
+    end;
+    [ false, true ].each do |fsl|
+      iseq = RubyVM::InstructionSequence.compile(code,
+                                                 frozen_string_literal: fsl)
+      assert_equal(true, iseq.eval,
+                  "[ruby-core:85542] [Bug #14475] fsl: #{fsl}")
+    end
+  end
+
   def test_branch_condition_backquote
     bug = '[ruby-core:80740] [Bug #13444] redefined backquote should be called'
     class << self

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -557,8 +557,9 @@ class TestRubyOptimization < Test::Unit::TestCase
       when "1.8.0"..."1.8.8" then :bar
       end
     end;
-    [ nil, { frozen_string_literal: true } ].each do |opt|
-      iseq = RubyVM::InstructionSequence.compile(code, nil, nil, opt)
+    [ true, false ].each do |opt|
+      iseq = RubyVM::InstructionSequence.compile(code,
+                                                 frozen_string_literal: opt)
       insn = iseq.disasm
       assert_match %r{putobject\s+#{Regexp.quote('"1.8.0"..."1.8.8"')}}, insn
       assert_match %r{putobject\s+#{Regexp.quote('"2.0.0".."2.3.2"')}}, insn

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -561,8 +561,12 @@ get_stack(void **addr, size_t *size)
     CHECK_ERR(pthread_attr_getstackaddr(&attr, addr));
     CHECK_ERR(pthread_attr_getstacksize(&attr, size));
 # endif
+# ifdef HAVE_PTHREAD_ATTR_GETGUARDSIZE
     CHECK_ERR(pthread_attr_getguardsize(&attr, &guard));
     *size -= guard;
+# else
+    *size -= getpagesize();
+# endif
     pthread_attr_destroy(&attr);
 #elif defined HAVE_PTHREAD_ATTR_GET_NP /* FreeBSD, DragonFly BSD, NetBSD */
     pthread_attr_t attr;

--- a/tool/ruby_vm/models/typemap.rb
+++ b/tool/ruby_vm/models/typemap.rb
@@ -18,6 +18,7 @@ RubyVM::Typemap = {
   "GENTRY"         => %w[G TS_GENTRY],
   "IC"             => %w[K TS_IC],
   "ID"             => %w[I TS_ID],
+  "ISE"            => %w[T TS_ISE],
   "ISEQ"           => %w[S TS_ISEQ],
   "OFFSET"         => %w[O TS_OFFSET],
   "VALUE"          => %w[V TS_VALUE],

--- a/vm_core.h
+++ b/vm_core.h
@@ -1013,6 +1013,7 @@ enum vm_svar_index {
 
 /* inline cache */
 typedef struct iseq_inline_cache_entry *IC;
+typedef union iseq_inline_storage_entry *ISE;
 typedef struct rb_call_info *CALL_INFO;
 typedef struct rb_call_cache *CALL_CACHE;
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -411,7 +411,11 @@ struct rb_iseq_constant_body {
 				      */
     struct rb_call_cache *cc_entries; /* size is ci_size = ci_kw_size */
 
-    VALUE mark_ary;     /* Array: includes operands which should be GC marked */
+    struct {
+      rb_num_t flip_count;
+      VALUE coverage;
+      VALUE original_iseq;
+    } variable;
 
     unsigned int local_table_size;
     unsigned int is_size;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3285,11 +3285,10 @@ vm_ic_update(IC ic, VALUE val, const VALUE *reg_ep)
 }
 
 static VALUE
-vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, IC ic)
+vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, ISE is)
 {
     rb_thread_t *th = rb_ec_thread_ptr(ec);
     rb_thread_t *const RUNNING_THREAD_ONCE_DONE = (rb_thread_t *)(0x1);
-    union iseq_inline_storage_entry *const is = (union iseq_inline_storage_entry *)ic;
 
   again:
     if (is->once.running_thread == RUNNING_THREAD_ONCE_DONE) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3298,10 +3298,10 @@ vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, IC ic)
     else if (is->once.running_thread == NULL) {
 	VALUE val;
 	is->once.running_thread = th;
-	val = is->once.value = rb_ensure(vm_once_exec, (VALUE)iseq, vm_once_clear, (VALUE)is);
+	val = rb_ensure(vm_once_exec, (VALUE)iseq, vm_once_clear, (VALUE)is);
+	RB_OBJ_WRITE(ec->cfp->iseq, &is->once.value, val);
 	/* is->once.running_thread is cleared by vm_once_clear() */
 	is->once.running_thread = RUNNING_THREAD_ONCE_DONE; /* success */
-	rb_iseq_add_mark_object(ec->cfp->iseq, val);
 	return val;
     }
     else if (is->once.running_thread == th) {


### PR DESCRIPTION
This pull request marks objects directly in bytecode rather than using the `mark_ary` for liveness.  Avoiding the `mark_ary` decreases memory usage of the application.  I observed a ~3% reduction in non-object allocations in a basic Rails application in production mode:

Before:

```
-----------------------------------------------------------------------
Zone DefaultMallocZone_0x101294000: 421350 nodes (62666528 bytes) 

    COUNT     BYTES       AVG   CLASS_NAME                                       TYPE    BINARY
    =====     =====       ===   ==========                                       ====    ======
   421230  62651360     148.7   non-object                                                                 
       35      6160     176.0   ImageLoaderMachOCompressed                       C++     dyld              
       31      5952     192.0   OS_xpc_dictionary                                ObjC    libxpc.dylib      
        8       512      64.0   CFBasicHash                                      CFType  CoreFoundation    
        4       384      96.0   NSLock                                           ObjC    Foundation        
        6       288      48.0   OS_xpc_string                                    ObjC    libxpc.dylib      
        3       272      90.7   OS_xpc_pipe                                      ObjC    libxpc.dylib      
        4       256      64.0   pthread_mutex_t                                  C       libpthread.dylib  
        2       224     112.0   NSRecursiveLock                                  ObjC    Foundation        
        5       160      32.0   NSMergePolicy                                    ObjC    CoreData          
        1       160     160.0   _NSThreadData                                    ObjC    Foundation        
        1       128     128.0   OS_dispatch_queue_serial                         ObjC    libdispatch.dylib 
        3       112      37.3   CFString                                         ObjC    CoreFoundation    
        1        80      80.0   OS_os_log                                        ObjC    libsystem_trace.dylib
        1        64      64.0   CFDictionary                                     ObjC    CoreFoundation    
        1        64      64.0   NSThread                                         ObjC    Foundation        
        1        48      48.0   NSArray                                          ObjC    CoreFoundation    
        1        48      48.0   OS_xpc_array                                     ObjC    libxpc.dylib      
        2        32      16.0   __NSPlaceholderArray                             ObjC    CoreFoundation    
        2        32      16.0   __NSPlaceholderDictionary                        ObjC    CoreFoundation    
        1        32      32.0   CFDictionary (Value Storage)                     C       CoreFoundation    
        1        32      32.0   CFDictionary (Weak Key Storage)                  C       CoreFoundation    
        1        32      32.0   NSMutableDictionary                              ObjC    CoreFoundation    
        1        32      32.0   OS_xpc_uint64                                    ObjC    libxpc.dylib      
        1        16      16.0   NSArray                                          ObjC    CoreFoundation    
        1        16      16.0   NSDictionary                                     ObjC    CoreFoundation    
        1        16      16.0   NSObject                                         ObjC    libobjc.A.dylib   
        1        16      16.0   __NSEnumerator0                                  ObjC    CoreFoundation  
```

After:

```
    COUNT     BYTES       AVG   CLASS_NAME                                       TYPE    BINARY
    =====     =====       ===   ==========                                       ====    ======
   408367  60495552     148.1   non-object                                                                 
       35      6160     176.0   ImageLoaderMachOCompressed                       C++     dyld              
       31      5952     192.0   OS_xpc_dictionary                                ObjC    libxpc.dylib      
        8       512      64.0   CFBasicHash                                      CFType  CoreFoundation    
        4       384      96.0   NSLock                                           ObjC    Foundation        
        6       288      48.0   OS_xpc_string                                    ObjC    libxpc.dylib      
        3       272      90.7   OS_xpc_pipe                                      ObjC    libxpc.dylib      
        4       256      64.0   pthread_mutex_t                                  C       libpthread.dylib  
        2       224     112.0   NSRecursiveLock                                  ObjC    Foundation        
        5       160      32.0   NSMergePolicy                                    ObjC    CoreData          
        1       160     160.0   _NSThreadData                                    ObjC    Foundation        
        1       128     128.0   OS_dispatch_queue_serial                         ObjC    libdispatch.dylib 
        3       112      37.3   CFString                                         ObjC    CoreFoundation    
        1        80      80.0   OS_os_log                                        ObjC    libsystem_trace.dylib
        1        64      64.0   CFDictionary                                     ObjC    CoreFoundation    
        1        64      64.0   NSThread                                         ObjC    Foundation        
        1        48      48.0   NSArray                                          ObjC    CoreFoundation    
        1        48      48.0   OS_xpc_array                                     ObjC    libxpc.dylib      
        2        32      16.0   __NSPlaceholderArray                             ObjC    CoreFoundation    
        2        32      16.0   __NSPlaceholderDictionary                        ObjC    CoreFoundation    
        1        32      32.0   CFDictionary (Value Storage)                     C       CoreFoundation    
        1        32      32.0   CFDictionary (Weak Key Storage)                  C       CoreFoundation    
        1        32      32.0   NSMutableDictionary                              ObjC    CoreFoundation    
        1        32      32.0   OS_xpc_uint64                                    ObjC    libxpc.dylib      
        1        16      16.0   NSArray                                          ObjC    CoreFoundation    
        1        16      16.0   NSDictionary                                     ObjC    CoreFoundation    
        1        16      16.0   NSObject                                         ObjC    libobjc.A.dylib   
        1        16      16.0   __NSEnumerator0                                  ObjC    CoreFoundation 
```

The more code we load, the more that is saved, so we need to test this on our application. 😀