### PR TITLE
Fix for 14634

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -4188,6 +4188,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     }
     rb_vm_living_threads_init(vm);
     rb_vm_living_threads_insert(vm, th);
+    vm->fork_gen++;
     rb_thread_sync_reset_all();
 
     vm->sleeper = 0;

--- a/thread.c
+++ b/thread.c
@@ -4189,7 +4189,6 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     rb_vm_living_threads_init(vm);
     rb_vm_living_threads_insert(vm, th);
     vm->fork_gen++;
-    rb_thread_sync_reset_all();
 
     vm->sleeper = 0;
     clear_coverage();

--- a/thread.c
+++ b/thread.c
@@ -4188,6 +4188,8 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     }
     rb_vm_living_threads_init(vm);
     rb_vm_living_threads_insert(vm, th);
+    rb_thread_sync_reset_all();
+
     vm->sleeper = 0;
     clear_coverage();
 }

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1295,6 +1295,7 @@ condvar_ptr(VALUE self)
 
     /* forked children can't reach into parent thread stacks */
     if (cv->fork_gen != fork_gen) {
+        cv->fork_gen = fork_gen;
         list_head_init(&cv->waitq);
     }
 

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -62,7 +62,6 @@ typedef struct rb_mutex_struct {
 static void rb_mutex_abandon_all(rb_mutex_t *mutexes);
 static void rb_mutex_abandon_keeping_mutexes(rb_thread_t *th);
 static void rb_mutex_abandon_locking_mutex(rb_thread_t *th);
-static void rb_thread_sync_reset_all(void);
 #endif
 static const char* rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t volatile *th);
 
@@ -544,17 +543,15 @@ void rb_mutex_allow_trap(VALUE self, int val)
 /* Queue */
 
 #define queue_waitq(q) UNALIGNED_MEMBER_PTR(q, waitq)
-#define queue_live(q) UNALIGNED_MEMBER_PTR(q, live)
 PACKED_STRUCT_UNALIGNED(struct rb_queue {
-    struct list_node live;
     struct list_head waitq;
+    rb_serial_t fork_gen;
     const VALUE que;
     int num_waiting;
 });
 
 #define szqueue_waitq(sq) UNALIGNED_MEMBER_PTR(sq, q.waitq)
 #define szqueue_pushq(sq) UNALIGNED_MEMBER_PTR(sq, pushq)
-#define szqueue_live(sq) UNALIGNED_MEMBER_PTR(sq, q.live)
 PACKED_STRUCT_UNALIGNED(struct rb_szqueue {
     struct rb_queue q;
     int num_waiting_push;
@@ -571,14 +568,6 @@ queue_mark(void *ptr)
     rb_gc_mark(q->que);
 }
 
-static void
-queue_free(void *ptr)
-{
-    struct rb_queue *q = ptr;
-    list_del(queue_live(q));
-    ruby_xfree(ptr);
-}
-
 static size_t
 queue_memsize(const void *ptr)
 {
@@ -587,7 +576,7 @@ queue_memsize(const void *ptr)
 
 static const rb_data_type_t queue_data_type = {
     "queue",
-    {queue_mark, queue_free, queue_memsize,},
+    {queue_mark, RUBY_TYPED_DEFAULT_FREE, queue_memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY|RUBY_TYPED_WB_PROTECTED
 };
 
@@ -599,8 +588,22 @@ queue_alloc(VALUE klass)
 
     obj = TypedData_Make_Struct(klass, struct rb_queue, &queue_data_type, q);
     list_head_init(queue_waitq(q));
-    list_add(&queue_list, queue_live(q));
     return obj;
+}
+
+static int
+queue_fork_check(struct rb_queue *q)
+{
+    rb_serial_t fork_gen = GET_VM()->fork_gen;
+
+    if (q->fork_gen == fork_gen) {
+        return 0;
+    }
+    /* forked children can't reach into parent thread stacks */
+    q->fork_gen = fork_gen;
+    list_head_init(queue_waitq(q));
+    q->num_waiting = 0;
+    return 1;
 }
 
 static struct rb_queue *
@@ -609,6 +612,8 @@ queue_ptr(VALUE obj)
     struct rb_queue *q;
 
     TypedData_Get_Struct(obj, struct rb_queue, &queue_data_type, q);
+    queue_fork_check(q);
+
     return q;
 }
 
@@ -622,14 +627,6 @@ szqueue_mark(void *ptr)
     queue_mark(&sq->q);
 }
 
-static void
-szqueue_free(void *ptr)
-{
-    struct rb_szqueue *sq = ptr;
-    list_del(szqueue_live(sq));
-    ruby_xfree(ptr);
-}
-
 static size_t
 szqueue_memsize(const void *ptr)
 {
@@ -638,7 +635,7 @@ szqueue_memsize(const void *ptr)
 
 static const rb_data_type_t szqueue_data_type = {
     "sized_queue",
-    {szqueue_mark, szqueue_free, szqueue_memsize,},
+    {szqueue_mark, RUBY_TYPED_DEFAULT_FREE, szqueue_memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY|RUBY_TYPED_WB_PROTECTED
 };
 
@@ -650,7 +647,6 @@ szqueue_alloc(VALUE klass)
 					&szqueue_data_type, sq);
     list_head_init(szqueue_waitq(sq));
     list_head_init(szqueue_pushq(sq));
-    list_add(&szqueue_list, szqueue_live(sq));
     return obj;
 }
 
@@ -660,6 +656,11 @@ szqueue_ptr(VALUE obj)
     struct rb_szqueue *sq;
 
     TypedData_Get_Struct(obj, struct rb_szqueue, &szqueue_data_type, sq);
+    if (queue_fork_check(&sq->q)) {
+        list_head_init(szqueue_pushq(sq));
+        sq->num_waiting_push = 0;
+    }
+
     return sq;
 }
 
@@ -1239,10 +1240,9 @@ rb_szqueue_empty_p(VALUE self)
 
 
 /* ConditionalVariable */
-/* TODO: maybe this can be IMEMO */
 struct rb_condvar {
     struct list_head waitq;
-    struct list_node live;
+    rb_serial_t fork_gen;
 };
 
 /*
@@ -1273,14 +1273,6 @@ struct rb_condvar {
  *    }
  */
 
-static void
-condvar_free(void *ptr)
-{
-    struct rb_condvar *cv = ptr;
-    list_del(&cv->live);
-    ruby_xfree(ptr);
-}
-
 static size_t
 condvar_memsize(const void *ptr)
 {
@@ -1289,7 +1281,7 @@ condvar_memsize(const void *ptr)
 
 static const rb_data_type_t cv_data_type = {
     "condvar",
-    {0, condvar_free, condvar_memsize,},
+    {0, RUBY_TYPED_DEFAULT_FREE, condvar_memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY|RUBY_TYPED_WB_PROTECTED
 };
 
@@ -1297,8 +1289,14 @@ static struct rb_condvar *
 condvar_ptr(VALUE self)
 {
     struct rb_condvar *cv;
+    rb_serial_t fork_gen = GET_VM()->fork_gen;
 
     TypedData_Get_Struct(self, struct rb_condvar, &cv_data_type, cv);
+
+    /* forked children can't reach into parent thread stacks */
+    if (cv->fork_gen != fork_gen) {
+        list_head_init(&cv->waitq);
+    }
 
     return cv;
 }
@@ -1311,7 +1309,6 @@ condvar_alloc(VALUE klass)
 
     obj = TypedData_Make_Struct(klass, struct rb_condvar, &cv_data_type, cv);
     list_head_init(&cv->waitq);
-    list_add(&condvar_list, &cv->live);
 
     return obj;
 }
@@ -1424,31 +1421,6 @@ define_thread_class(VALUE outer, const char *name, VALUE super)
     rb_define_const(rb_cObject, name, klass);
     return klass;
 }
-
-#if defined(HAVE_WORKING_FORK)
-/* we must not reference stacks of dead threads in a forked child */
-static void
-rb_thread_sync_reset_all(void)
-{
-    struct rb_queue *q = 0;
-    struct rb_szqueue *sq = 0;
-    struct rb_condvar *cv = 0;
-
-    list_for_each(&queue_list, q, live) {
-        list_head_init(queue_waitq(q));
-        q->num_waiting = 0;
-    }
-    list_for_each(&szqueue_list, sq, q.live) {
-        list_head_init(szqueue_waitq(sq));
-        list_head_init(szqueue_pushq(sq));
-        sq->num_waiting_push = 0;
-        sq->q.num_waiting = 0;
-    }
-    list_for_each(&condvar_list, cv, live) {
-        list_head_init(&cv->waitq);
-    }
-}
-#endif
 
 static void
 Init_thread_sync(void)

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -4,6 +4,14 @@
 static VALUE rb_cMutex, rb_cQueue, rb_cSizedQueue, rb_cConditionVariable;
 static VALUE rb_eClosedQueueError;
 
+/*
+ * keep these globally so we can walk and reinitialize them at fork
+ * in the child process
+ */
+static LIST_HEAD(szqueue_list);
+static LIST_HEAD(queue_list);
+static LIST_HEAD(condvar_list);
+
 /* sync_waiter is always on-stack */
 struct sync_waiter {
     rb_thread_t *th;
@@ -54,6 +62,7 @@ typedef struct rb_mutex_struct {
 static void rb_mutex_abandon_all(rb_mutex_t *mutexes);
 static void rb_mutex_abandon_keeping_mutexes(rb_thread_t *th);
 static void rb_mutex_abandon_locking_mutex(rb_thread_t *th);
+static void rb_thread_sync_reset_all(void);
 #endif
 static const char* rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t volatile *th);
 
@@ -535,7 +544,9 @@ void rb_mutex_allow_trap(VALUE self, int val)
 /* Queue */
 
 #define queue_waitq(q) UNALIGNED_MEMBER_PTR(q, waitq)
+#define queue_live(q) UNALIGNED_MEMBER_PTR(q, live)
 PACKED_STRUCT_UNALIGNED(struct rb_queue {
+    struct list_node live;
     struct list_head waitq;
     const VALUE que;
     int num_waiting;
@@ -543,6 +554,7 @@ PACKED_STRUCT_UNALIGNED(struct rb_queue {
 
 #define szqueue_waitq(sq) UNALIGNED_MEMBER_PTR(sq, q.waitq)
 #define szqueue_pushq(sq) UNALIGNED_MEMBER_PTR(sq, pushq)
+#define szqueue_live(sq) UNALIGNED_MEMBER_PTR(sq, q.live)
 PACKED_STRUCT_UNALIGNED(struct rb_szqueue {
     struct rb_queue q;
     int num_waiting_push;
@@ -559,6 +571,14 @@ queue_mark(void *ptr)
     rb_gc_mark(q->que);
 }
 
+static void
+queue_free(void *ptr)
+{
+    struct rb_queue *q = ptr;
+    list_del(queue_live(q));
+    ruby_xfree(ptr);
+}
+
 static size_t
 queue_memsize(const void *ptr)
 {
@@ -567,7 +587,7 @@ queue_memsize(const void *ptr)
 
 static const rb_data_type_t queue_data_type = {
     "queue",
-    {queue_mark, RUBY_TYPED_DEFAULT_FREE, queue_memsize,},
+    {queue_mark, queue_free, queue_memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY|RUBY_TYPED_WB_PROTECTED
 };
 
@@ -579,6 +599,7 @@ queue_alloc(VALUE klass)
 
     obj = TypedData_Make_Struct(klass, struct rb_queue, &queue_data_type, q);
     list_head_init(queue_waitq(q));
+    list_add(&queue_list, queue_live(q));
     return obj;
 }
 
@@ -601,6 +622,14 @@ szqueue_mark(void *ptr)
     queue_mark(&sq->q);
 }
 
+static void
+szqueue_free(void *ptr)
+{
+    struct rb_szqueue *sq = ptr;
+    list_del(szqueue_live(sq));
+    ruby_xfree(ptr);
+}
+
 static size_t
 szqueue_memsize(const void *ptr)
 {
@@ -609,7 +638,7 @@ szqueue_memsize(const void *ptr)
 
 static const rb_data_type_t szqueue_data_type = {
     "sized_queue",
-    {szqueue_mark, RUBY_TYPED_DEFAULT_FREE, szqueue_memsize,},
+    {szqueue_mark, szqueue_free, szqueue_memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY|RUBY_TYPED_WB_PROTECTED
 };
 
@@ -621,6 +650,7 @@ szqueue_alloc(VALUE klass)
 					&szqueue_data_type, sq);
     list_head_init(szqueue_waitq(sq));
     list_head_init(szqueue_pushq(sq));
+    list_add(&szqueue_list, szqueue_live(sq));
     return obj;
 }
 
@@ -866,7 +896,7 @@ queue_do_pop(VALUE self, struct rb_queue *q, int should_block)
 	    list_add_tail(&qw.as.q->waitq, &qw.w.node);
 	    qw.as.q->num_waiting++;
 
-	    rb_ensure(queue_sleep, Qfalse, queue_sleep_done, (VALUE)&qw);
+	    rb_ensure(queue_sleep, self, queue_sleep_done, (VALUE)&qw);
 	}
     }
 
@@ -1108,7 +1138,7 @@ rb_szqueue_push(int argc, VALUE *argv, VALUE self)
 	    list_add_tail(pushq, &qw.w.node);
 	    sq->num_waiting_push++;
 
-	    rb_ensure(queue_sleep, Qfalse, szqueue_sleep_done, (VALUE)&qw);
+	    rb_ensure(queue_sleep, self, szqueue_sleep_done, (VALUE)&qw);
 	}
     }
 
@@ -1212,6 +1242,7 @@ rb_szqueue_empty_p(VALUE self)
 /* TODO: maybe this can be IMEMO */
 struct rb_condvar {
     struct list_head waitq;
+    struct list_node live;
 };
 
 /*
@@ -1242,6 +1273,14 @@ struct rb_condvar {
  *    }
  */
 
+static void
+condvar_free(void *ptr)
+{
+    struct rb_condvar *cv = ptr;
+    list_del(&cv->live);
+    ruby_xfree(ptr);
+}
+
 static size_t
 condvar_memsize(const void *ptr)
 {
@@ -1250,7 +1289,7 @@ condvar_memsize(const void *ptr)
 
 static const rb_data_type_t cv_data_type = {
     "condvar",
-    {0, RUBY_TYPED_DEFAULT_FREE, condvar_memsize,},
+    {0, condvar_free, condvar_memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY|RUBY_TYPED_WB_PROTECTED
 };
 
@@ -1272,6 +1311,7 @@ condvar_alloc(VALUE klass)
 
     obj = TypedData_Make_Struct(klass, struct rb_condvar, &cv_data_type, cv);
     list_head_init(&cv->waitq);
+    list_add(&condvar_list, &cv->live);
 
     return obj;
 }
@@ -1384,6 +1424,31 @@ define_thread_class(VALUE outer, const char *name, VALUE super)
     rb_define_const(rb_cObject, name, klass);
     return klass;
 }
+
+#if defined(HAVE_WORKING_FORK)
+/* we must not reference stacks of dead threads in a forked child */
+static void
+rb_thread_sync_reset_all(void)
+{
+    struct rb_queue *q = 0;
+    struct rb_szqueue *sq = 0;
+    struct rb_condvar *cv = 0;
+
+    list_for_each(&queue_list, q, live) {
+        list_head_init(queue_waitq(q));
+        q->num_waiting = 0;
+    }
+    list_for_each(&szqueue_list, sq, q.live) {
+        list_head_init(szqueue_waitq(sq));
+        list_head_init(szqueue_pushq(sq));
+        sq->num_waiting_push = 0;
+        sq->q.num_waiting = 0;
+    }
+    list_for_each(&condvar_list, cv, live) {
+        list_head_init(&cv->waitq);
+    }
+}
+#endif
 
 static void
 Init_thread_sync(void)

--- a/vm_core.h
+++ b/vm_core.h
@@ -507,6 +507,7 @@ typedef struct rb_vm_struct {
     struct rb_thread_struct *main_thread;
     struct rb_thread_struct *running_thread;
 
+    rb_serial_t fork_gen;
     struct list_head waiting_fds; /* <=> struct waiting_fd */
     struct list_head living_threads;
     size_t living_thread_num;


### PR DESCRIPTION
These are just backports for [this bug](https://bugs.ruby-lang.org/issues/14634)

/cc @kivikakk 