### PR TITLE
Add a DTrace probe for string capacity resizes

### DIFF
--- a/probes.d
+++ b/probes.d
@@ -152,6 +152,18 @@ provider ruby {
   probe string__create(long length, const char *filename, int lineno);
 
   /*
+     ruby:::string-capa-resize(from_capa, to_capa, filename, lineno);
+
+     This probe is fired when String capacity is changed
+
+      * `from_capa` the current capacity of the string (long)
+      * `to_capa` the new capacity of the string (long)
+      * `filename` the name of the file where the string is allocated (string)
+      * `lineno` the line number in the file where the string is allocated (int)
+  */
+  probe string__capa__resize(long from_capa, long to_capa, const char *filename, int lineno);
+
+  /*
      ruby:::symbol-create(str, filename, lineno);
 
      This probe is fired when a Symbol is about to be allocated.

--- a/string.c
+++ b/string.c
@@ -132,6 +132,18 @@ VALUE rb_cSymbol;
     RESIZE_CAPA_TERM(str,capacity,termlen);\
 } while (0)
 #define RESIZE_CAPA_TERM(str,capacity,termlen) do {\
+    if (UNLIKELY(RUBY_DTRACE_STRING_CAPA_RESIZE_ENABLED())) {\
+	int dtrace_line; \
+	const char *dtrace_file = rb_source_location_cstr(&dtrace_line); \
+	long prev_capa;\
+	if (STR_EMBED_P(str)) {\
+	    prev_capa = RSTRING_EMBED_LEN_MAX + 1 - termlen;\
+	} else {\
+	    prev_capa = RSTRING(str)->as.heap.aux.capa;\
+	}\
+	if (!dtrace_file) dtrace_file = ""; \
+	RUBY_DTRACE_STRING_CAPA_RESIZE(prev_capa, capacity, dtrace_file, dtrace_line);\
+    }\
     if (STR_EMBED_P(str)) {\
 	if (!STR_EMBEDDABLE_P(capacity, termlen)) {\
 	    char *const tmp = ALLOC_N(char, (size_t)(capacity) + (termlen));\


### PR DESCRIPTION
Adds a DTrace probe that fires when a string is resized.

Example:

```
$ cat resize.d 
#pragma D option quiet

ruby*:::string-capa-resize
{
  printf("string resize from %d to %d (%s:%d)\n", arg0, arg1, copyinstr(arg2), arg3)
}
```

```
$ cat my_test.rb
require 'test_helper'

class UsersControllerTest < ActionDispatch::IntegrationTest
  def test_get_new
    get new_user_url
    assert_response :success
  end
end

puts "#" * 90

20.times do
  Minitest.run_one_method UsersControllerTest, :test_get_new
end

exit!
```

Run the test:

```
$ sudo dtrace -q -s resize.d -c'/Users/aaron/.rbenv/versions/ruby-trunk/bin/ruby -I lib:test my_test.rb'
```