### PR TITLE
fix: YYUSE -> YY_USE

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -13331,7 +13331,7 @@ count_char(const char *str, int c)
 RUBY_FUNC_EXPORTED size_t
 rb_yytnamerr(struct parser_params *p, char *yyres, const char *yystr)
 {
-    YYUSE(p);
+    YY_USE(p);
     if (*yystr == '"') {
 	size_t yyn = 0, bquote = 0;
 	const char *yyp = yystr;


### PR DESCRIPTION
From debian sid:

```bash
/home/xlgmokha/src/github.com/github/github/vendor/ruby/src/parse.y:12687: undefined reference to `YYUSE'
/usr/bin/ld: /home/xlgmokha/src/github.com/github/github/vendor/ruby/src/parse.y:12687: undefined reference to `YYUSE'
collect2: error: ld returned 1 exit status
make: *** [Makefile:271: miniruby] Error 1
Failed to build Ruby
```

```bash
モ bison --version
bison (GNU Bison) 3.7.5
Written by Robert Corbett and Richard Stallman.

Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

* [style: YYUSE is private, make it YY_USE](https://lists.defectivebydesign.org/archive/html/bison-patches/2021-01/msg00095.html)