### PR TITLE
Add workflow to keep repo in sync with Ruby upstream

### DIFF
--- a/.github/workflows/sync-fork-default-branch.yml
+++ b/.github/workflows/sync-fork-default-branch.yml
@@ -1,0 +1,20 @@
+name: Sync Fork's Default Branch
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: "0 13 * * 1" # Mondays at 1pm UTC
+
+jobs:
+  sync-fork:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Sync Repo
+      run: gh repo sync github/ruby

--- a/.github/workflows/sync-fork-default-branch.yml
+++ b/.github/workflows/sync-fork-default-branch.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 13 * * 1" # Mondays at 1pm UTC
+    - cron: "0 0 * * *" # every day at midnight UTC
 
 jobs:
   sync-fork:


### PR DESCRIPTION
This adds a workflow to keep this fork up-to-date with Ruby upstream. I arbitrarily made this workflow run every day but we can change that to anything else. ✨ 