### PR TITLE
A few backports

### DIFF
--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -1190,3 +1190,12 @@ assert_equal 'DC', %q{
   test2 o1, [], block
   $result.join
 }
+
+assert_equal 'ok', %q{
+  def foo
+    binding
+    ["ok"].first
+  end
+  foo
+  foo
+}, '[Bug #20178]'

--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -706,8 +706,6 @@ SRC
 
   have_func("pthread_create")
   have_func("pthread_detach")
-  have_func("pthread_attr_setaffinity_np")
-  have_func("sched_getcpu")
 
   $VPATH << '$(topdir)' << '$(top_srcdir)'
   create_makefile("socket")

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -511,6 +511,11 @@ start:
     }
     pthread_detach(th);
 
+    int r;
+    if ((r = pthread_attr_destroy(&attr)) != 0) {
+        rb_bug_errno("pthread_attr_destroy", r);
+    }
+
     rb_thread_call_without_gvl2(wait_getaddrinfo, arg, cancel_getaddrinfo, arg);
 
     int need_free = 0;
@@ -732,11 +737,16 @@ start:
 #endif
 
     pthread_t th;
-    if (do_pthread_create(&th, 0, do_getnameinfo, arg) != 0) {
+    if (do_pthread_create(&th, &attr, do_getnameinfo, arg) != 0) {
         free_getnameinfo_arg(arg);
         return EAI_AGAIN;
     }
     pthread_detach(th);
+
+    int r;
+    if ((r = pthread_attr_destroy(&attr)) != 0) {
+        rb_bug_errno("pthread_attr_destroy", r);
+    }
 
     rb_thread_call_without_gvl2(wait_getnameinfo, arg, cancel_getnameinfo, arg);
 

--- a/hash.c
+++ b/hash.c
@@ -1557,7 +1557,15 @@ hash_copy(VALUE ret, VALUE hash)
 static VALUE
 hash_dup_with_compare_by_id(VALUE hash)
 {
-    return hash_copy(copy_compare_by_id(rb_hash_new(), hash), hash);
+    VALUE dup = hash_alloc_flags(rb_cHash, 0, Qnil, RHASH_ST_TABLE_P(hash));
+    if (RHASH_ST_TABLE_P(hash)) {
+        RHASH_SET_ST_FLAG(dup);
+    }
+    else {
+        RHASH_UNSET_ST_FLAG(dup);
+    }
+
+    return hash_copy(dup, hash);
 }
 
 static VALUE

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1458,6 +1458,16 @@ class TestHash < Test::Unit::TestCase
     assert_predicate(h.dup, :compare_by_identity?, bug8703)
   end
 
+  def test_compare_by_identy_memory_leak
+    assert_no_memory_leak([], "", "#{<<~"begin;"}\n#{<<~'end;'}", "[Bug #20145]", rss: true)
+    begin;
+      h = { 1 => 2 }.compare_by_identity
+      1_000_000.times do
+        h.select { false }
+      end
+    end;
+  end
+
   def test_same_key
     bug9646 = '[ruby-dev:48047] [Bug #9646] Infinite loop at Hash#each'
     h = @cls[a=[], 1]


### PR DESCRIPTION
A few backported fixes.

* Identhash memory leak https://bugs.ruby-lang.org/issues/20145
* Extra match allocations https://bugs.ruby-lang.org/issues/20104
* OOB stack read on `-O0` https://bugs.ruby-lang.org/issues/20178 
* A couple issues and problems fixed with the new DNS resolving: https://bugs.ruby-lang.org/issues/20149 (from Adam) https://bugs.ruby-lang.org/issues/20172

For https://github.com/github/ruby-architecture/issues/915