### PR TITLE
[REFERENCE] Backport thread scheduling

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -170,7 +170,7 @@ static inline void blocking_region_end(rb_thread_t *th, struct rb_blocking_regio
 #define THREAD_BLOCKING_BEGIN(th) do { \
   struct rb_thread_sched * const sched = TH_SCHED(th); \
   RB_VM_SAVE_MACHINE_CONTEXT(th); \
-  thread_sched_to_waiting((sched), (th));
+  thread_sched_to_waiting((sched), (th), true);
 
 #define THREAD_BLOCKING_END(th) \
   thread_sched_to_running((sched), (th)); \
@@ -194,7 +194,7 @@ static inline void blocking_region_end(rb_thread_t *th, struct rb_blocking_regio
         /* Important that this is inlined into the macro, and not part of \
          * blocking_region_begin - see bug #20493 */ \
         RB_VM_SAVE_MACHINE_CONTEXT(th); \
-        thread_sched_to_waiting(TH_SCHED(th), th); \
+        thread_sched_to_waiting(TH_SCHED(th), th, false); \
         exec; \
         blocking_region_end(th, &__region); \
     }; \
@@ -2092,7 +2092,7 @@ rb_thread_call_with_gvl(void *(*func)(void *), void *data1)
     int released = blocking_region_begin(th, brb, prev_unblock.func, prev_unblock.arg, FALSE);
     RUBY_ASSERT_ALWAYS(released);
     RB_VM_SAVE_MACHINE_CONTEXT(th);
-    thread_sched_to_waiting(TH_SCHED(th), th);
+    thread_sched_to_waiting(TH_SCHED(th), th, true);
     return r;
 }
 

--- a/thread_none.c
+++ b/thread_none.c
@@ -26,11 +26,11 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 }
 
 static void
-thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th)
+thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th, bool yield_immediately)
 {
 }
 
-#define thread_sched_to_dead thread_sched_to_waiting
+#define thread_sched_to_dead(a,b) thread_sched_to_waiting(a,b,true)
 
 static void
 thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -883,7 +883,7 @@ thread_sched_wait_running_turn(struct rb_thread_sched *sched, rb_thread_t *th, b
                 }
                 thread_sched_set_locked(sched, th);
 
-                if (sched->runnable_hot_th != NULL) {
+                if (sched->runnable_hot_th != NULL && sched->runnable_hot_th_waiting) {
                     VM_ASSERT(sched->runnable_hot_th != th);
                     // Give the hot thread a chance to preempt, if it's actively spinning.
                     // On multicore, this reduces the rate of core-switching. On single-core it
@@ -943,6 +943,7 @@ thread_sched_wait_running_turn(struct rb_thread_sched *sched, rb_thread_t *th, b
     // Control transfer to the current thread is now complete. The original thread
     // cannot steal control at this point.
     sched->runnable_hot_th = NULL;
+    sched->runnable_hot_th_waiting = 0;
 
     // VM_ASSERT(ractor_sched_running_threads_contain_p(th->vm, th)); need locking
     RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_RESUMED, th);
@@ -980,6 +981,13 @@ thread_sched_to_running_common(struct rb_thread_sched *sched, rb_thread_t *th)
 static void
 thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 {
+    // We are reading and writing these sched fields without lock cover, but
+    // there are no correctness issues resulting from stale cache or delayed writeback.
+    // When it works, this causes the next-scheduled thread to yield the sched lock
+    // briefly so that we can grab it if we're still spinning (not descheduled yet).
+    if (sched->runnable_hot_th == th) {
+        sched->runnable_hot_th_waiting = 1;
+    }
     thread_sched_lock(sched, th);
     {
         thread_sched_to_running_common(sched, th);
@@ -1053,6 +1061,7 @@ thread_sched_to_waiting_common(struct rb_thread_sched *sched, rb_thread_t *th, b
     native_thread_dedicated_inc(th->vm, th->ractor, th->nt);
     if (!yield_immediately) {
         sched->runnable_hot_th = th;
+        sched->runnable_hot_th_waiting = 0;
     }
     thread_sched_wakeup_next_thread(sched, th, false);
 }

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -56,6 +56,9 @@ struct rb_thread_sched_item {
         // connected to ractor->threads.sched.reqdyq
         // locked by ractor->threads.sched.lock
         struct ccan_list_node readyq;
+        // Indicates whether thread is on the readyq.
+        // There is no clear relationship between this and th->status.
+        bool is_ready;
 
         // connected to vm->ractor.sched.timeslice_threads
         // locked by vm->ractor.sched.lock
@@ -127,6 +130,10 @@ struct rb_thread_sched {
     struct rb_thread_struct *lock_owner;
 #endif
     struct rb_thread_struct *running; // running thread or NULL
+    // Most recently running thread or NULL. If this thread wakes up before the newly running
+    // thread completes the transfer of control, it can interrupt and resume running.
+    // The new thread clears this field when it takes control.
+    struct rb_thread_struct *runnable_hot_th;
     bool is_running;
     bool is_running_timeslice;
     bool enable_mn_threads;

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -134,6 +134,7 @@ struct rb_thread_sched {
     // thread completes the transfer of control, it can interrupt and resume running.
     // The new thread clears this field when it takes control.
     struct rb_thread_struct *runnable_hot_th;
+    int runnable_hot_th_waiting;
     bool is_running;
     bool is_running_timeslice;
     bool enable_mn_threads;

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -132,18 +132,22 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
     if (GVL_DEBUG) fprintf(stderr, "gvl acquire (%p): acquire\n", th);
 }
 
-#define thread_sched_to_dead thread_sched_to_waiting
-
 static void
-thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th)
+thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th, bool yield_immediately)
 {
     ReleaseMutex(sched->lock);
 }
 
 static void
+thread_sched_to_dead(struct rb_thread_sched *sched, rb_thread_t *th)
+{
+    thread_sched_to_waiting(sched, th, true);
+}
+
+static void
 thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)
 {
-    thread_sched_to_waiting(sched, th);
+    thread_sched_to_waiting(sched, th, true);
     native_thread_yield();
     thread_sched_to_running(sched, th);
 }


### PR DESCRIPTION
This is a back port of the upstream thread scheduling changes backported based on latest `ruby_4_0` upstream. Backported via,

```
git cherry-pick 467c9abe4bfca663103d7276b2c0fc583c86ec34 
git cherry-pick cc128b133fd2f846ea666bb5231af675f26a31d
```

This includes our previous back port (`82bb7e7a8db6eacf169e5b3d2758efe3ac6cf8cf` https://github.com/ruby/ruby/pull/16103) as well as the new Shopify suggested back port (`0f484dca87f7a667f2104ae85352397031093950` https://github.com/ruby/ruby/pull/16434) for faster class initialization fixing a regression in 4.0. These back ports are already present in the `ruby_4_0` branch, so don't appear in this PR.

I believe this does remove the `DLOPEN ERROR: %s - %s\n` debug message added in `5ebc91148524044d6b216c41466169fdbccba993` https://github.com/github/ruby/compare/ruby_4_0...github:ruby:4_0_1-github1

and we should decide if we still want/need that patch.